### PR TITLE
Backoff attempts to label node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ cython_debug/
 
 # Requirements are generated from Poetry
 requirements.txt
+
+# VSCode
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "joule.providers",
     ],
     install_requires=[
+        "backoff",
         "boto3",
         "boto3-stubs[autoscaling,sqs]",
         "click",


### PR DESCRIPTION
`--wait-ready` is not enough to guarantee node is ready in Kubernetes' world.  We need to try again if it fails, or cleanup gets broken.