### PR TITLE
Initial work to fix the big bang issue

### DIFF
--- a/joule/providers/__init__.py
+++ b/joule/providers/__init__.py
@@ -23,7 +23,8 @@ class BaseProvider(ABC):
         """
         :param: application: BaseApplication
         """
-        self.applications = applications
+        self.applications: tuple = applications
+        self._tag_enrolled: dict = {"Key": "Joule-Enrolled", "Value": "1"}
 
     @abstractmethod
     def mark_essential(self) -> None:
@@ -32,6 +33,23 @@ class BaseProvider(ABC):
         termination during a scale event.
 
         :return: None
+        """
+
+    @abstractmethod
+    def mark_enrolled(self) -> None:
+        """
+        Mark this instance as being enrolled in the application's cluster.
+
+        :return: None
+        """
+
+    @abstractmethod
+    def is_enrolled(self) -> bool:
+        """
+        Return whether or not this instance has been enrolled into the
+        application's cluster.
+
+        :return: Boolean
         """
 
     @abstractmethod
@@ -80,6 +98,7 @@ class BaseProvider(ABC):
                     for app in self.applications:
                         if event.application == app:
                             app.join(self, event)
+                    self.mark_enrolled()
 
                 elif event.event is Events.LAUNCH:
                     logging.info("LAUNCH event.")

--- a/joule/providers/aws.py
+++ b/joule/providers/aws.py
@@ -93,17 +93,15 @@ class AwsProvider(BaseProvider):
             Filters=[
                 {"Name": "resource-id", "Values": [self._instance_id]},
                 {
-                    "Name": "tag",
-                    "Values": [
-                        "{}={}".format(
-                            self._tag_enrolled["Key"], self._tag_enrolled["Value"]
-                        )
-                    ],
+                    "Name": "key",
+                    "Values": [self._tag_enrolled["Key"]],
                 },
             ],
         )
 
-        return result.get("Tags", False) is not False
+        if result.get("Tags", None):
+            return True
+        return False  # When none or empty list (no matches for tag key).
 
     def get_events_from_message_queue(self) -> Iterator[Optional[Event]]:
         """

--- a/joule/providers/aws.py
+++ b/joule/providers/aws.py
@@ -4,9 +4,10 @@ import logging
 
 from datetime import datetime
 from ec2_metadata import ec2_metadata
-from typing import Iterator, Optional
+from typing import Iterator, Optional, List, Dictionary
 
 from mypy_boto3_autoscaling.client import AutoScalingClient
+from mypy_boto3_ec2 import EC2Client
 from mypy_boto3_sqs.service_resource import Message, Queue
 
 from joule.providers import BaseProvider, Event, Events, logging
@@ -27,7 +28,7 @@ class AwsProvider(BaseProvider):
 
         super().__init__(*applications)
 
-        self.instance_id: str = ec2_metadata.instance_id
+        self._instance_id: str = ec2_metadata.instance_id
 
         self._region: str = ec2_metadata.region
 
@@ -36,11 +37,12 @@ class AwsProvider(BaseProvider):
         ][
             0
         ]  # Get first queue found.
-        self.queue: Queue = boto3.resource("sqs", region_name=self._region).Queue(
+        self._queue: Queue = boto3.resource("sqs", region_name=self._region).Queue(
             queue_url
         )
 
-        self.asg: AutoScalingClient = boto3.client(
+        self._ec2: EC2Client = boto3.client("ec2", region_name=self._region)
+        self._asg: AutoScalingClient = boto3.client(
             "autoscaling", region_name=self._region
         )
 
@@ -54,18 +56,49 @@ class AwsProvider(BaseProvider):
         if datetime.now().second != 0:
             return  # Run every minute.
 
-        asg_name: str = self.asg.describe_auto_scaling_instances(
+        asg_name: str = self._asg.describe_auto_scaling_instances(
             InstanceIds=[ec2_metadata.instance_id], MaxRecords=1
         )["AutoScalingInstances"][0]["AutoScalingGroupName"]
 
         for app in self.applications:
             is_essential: bool = app.is_essential()
-            self.asg.set_instance_protection(
+            self._asg.set_instance_protection(
                 InstanceIds=[ec2_metadata.instance_id],
                 AutoScalingGroupName=asg_name,
                 ProtectedFromScaleIn=is_essential,
             )
             logging.debug("essential={}".format(is_essential))
+
+    def mark_enrolled(self) -> None:
+        """
+        Mark this instance as being enrolled in the application's cluster.
+
+        :return: None
+        """
+        self._ec2.create_tags(Resources=[self._instance_id], Tags=[self._tag_enrolled])
+
+    def is_enrolled(self) -> bool:
+        """
+        Return whether or not this instance has been enrolled into the
+        application's cluster.
+
+        :return: Boolean
+        """
+        result: dict = self._ec2.describe_tags(
+            Filters=[
+                {"Name": "resource-id", "Values": [self._instance_id]},
+                {
+                    "Name": "tag",
+                    "Values": [
+                        "{}={}".format(
+                            self._tag_enrolled["Key"], self._tag_enrolled["Value"]
+                        )
+                    ],
+                },
+            ],
+        )
+
+        return result.get("Tags", False)
 
     def get_events_from_message_queue(self) -> Iterator[Optional[Event]]:
         """
@@ -73,25 +106,30 @@ class AwsProvider(BaseProvider):
 
         :return: Event
         """
-        rx: list[Message] = self.queue.receive_messages()
+        rx: List[Message] = self._queue.receive_messages()
 
         for msg in rx:
             try:
-                loaded: dict[str, str] = json.loads(json.loads(msg.body).get("Message"))
+                loaded: Dictionary[str, str] = json.loads(
+                    json.loads(msg.body).get("Message")
+                )
             except TypeError:
-                loaded: dict[str, str] = json.loads(msg.body)
+                loaded: Dictionary[str, str] = json.loads(msg.body)
 
-            if loaded.get("Event") == "autoscaling:EC2_INSTANCE_LAUNCH":
-                msg.delete()
-                yield Event(event=Events.LAUNCH, instance=loaded["EC2InstanceId"])
+            if self.is_enrolled():
+                if loaded.get("Event") == "autoscaling:EC2_INSTANCE_LAUNCH":
+                    msg.delete()
+                    yield Event(event=Events.LAUNCH, instance=loaded["EC2InstanceId"])
 
-            if loaded.get("Event") == "autoscaling:EC2_INSTANCE_TERMINATE":
-                msg.delete()
-                yield Event(event=Events.TERMINATE, instance=loaded["EC2InstanceId"])
+                if loaded.get("Event") == "autoscaling:EC2_INSTANCE_TERMINATE":
+                    msg.delete()
+                    yield Event(
+                        event=Events.TERMINATE, instance=loaded["EC2InstanceId"]
+                    )
 
             for app in self.applications:
                 if loaded.get("Event") == "{}:join".format(app.name):
-                    if loaded.get("EC2InstanceId") == self.instance_id:
+                    if loaded.get("EC2InstanceId") == self._instance_id:
                         msg.delete()
                         yield Event(
                             event=Events.JOIN,
@@ -113,7 +151,7 @@ class AwsProvider(BaseProvider):
         :param payload: Dictionary
         :return: None
         """
-        self.queue.send_message(
+        self._queue.send_message(
             MessageBody=json.dumps(
                 {
                     "Event": "{}:join".format(application.name),

--- a/joule/providers/aws.py
+++ b/joule/providers/aws.py
@@ -4,7 +4,7 @@ import logging
 
 from datetime import datetime
 from ec2_metadata import ec2_metadata
-from typing import Iterator, Optional, List, Dictionary
+from typing import Iterator, Optional, List, Dict
 
 from mypy_boto3_autoscaling.client import AutoScalingClient
 from mypy_boto3_ec2 import EC2Client
@@ -113,11 +113,11 @@ class AwsProvider(BaseProvider):
 
         for msg in rx:
             try:
-                loaded: Dictionary[str, str] = json.loads(
+                loaded: Dict[str, str] = json.loads(
                     json.loads(msg.body).get("Message")
                 )
             except TypeError:
-                loaded: Dictionary[str, str] = json.loads(msg.body)
+                loaded: Dict[str, str] = json.loads(msg.body)
 
             if self.is_enrolled():
                 if loaded.get("Event") == "autoscaling:EC2_INSTANCE_LAUNCH":

--- a/joule/providers/aws.py
+++ b/joule/providers/aws.py
@@ -75,7 +75,12 @@ class AwsProvider(BaseProvider):
 
         :return: None
         """
-        self._ec2.create_tags(Resources=[self._instance_id], Tags=[self._tag_enrolled])
+        self._ec2.create_tags(
+            Resources=[self._instance_id],
+            Tags=[
+                {"Key": self._tag_enrolled["Key"], "Value": self._tag_enrolled["Value"]}
+            ],
+        )
 
     def is_enrolled(self) -> bool:
         """
@@ -98,7 +103,7 @@ class AwsProvider(BaseProvider):
             ],
         )
 
-        return result.get("Tags", False)
+        return result.get("Tags", False) is not False
 
     def get_events_from_message_queue(self) -> Iterator[Optional[Event]]:
         """

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         "backoff",
         "boto3",
-        "boto3-stubs[autoscaling,sqs]",
+        "boto3-stubs[autoscaling,ec2,sqs]",
         "click",
         "ec2-metadata",
         "pyyaml",


### PR DESCRIPTION
This is to fix the fractured clustering when starting with a large initial scale group.  Instances are tagged once they’ve executed a “JOIN” event, meaning they should be on the application cluster.  Only instances tagged this way are allowed to process “LAUNCH” and “TERMINATE” events.

This will require a way to tag 1 initial instance in CloudFormation (for AWS).