### PR TITLE
Align key with AWS practices

### DIFF
--- a/joule/providers/__init__.py
+++ b/joule/providers/__init__.py
@@ -24,7 +24,7 @@ class BaseProvider(ABC):
         :param: application: BaseApplication
         """
         self.applications: tuple = applications
-        self._tag_enrolled: dict = {"Key": "Joule-Enrolled", "Value": "1"}
+        self._tag_enrolled: dict = {"Key": "joule:enrolled", "Value": "1"}
 
     @abstractmethod
     def mark_essential(self) -> None:


### PR DESCRIPTION
As the title suggests, this is to make the enrolled tag name align with AWS best practices