### PR TITLE
Add CF parameters. Fix queue handling.

### DIFF
--- a/examples/aws-microk8s/README.md
+++ b/examples/aws-microk8s/README.md
@@ -14,7 +14,7 @@ The launch template specifies the type of EC2 instances to be created, as well a
 
 #### User Data
 
-The `UserData` section of the launch template is what installs and configures MicroK8s and Joule. It's formatted in base64 so, to edit it, you must first pipe the string into `base64 -d` and then reformat with `base64` before replacing the string in the template.
+The `UserData` section of the launch template is what installs and configures MicroK8s and Joule.
 
 ### Auto Scaling Group
 

--- a/examples/aws-microk8s/cloud-formation.yaml
+++ b/examples/aws-microk8s/cloud-formation.yaml
@@ -119,18 +119,16 @@ Resources:
       LaunchTemplateData:
         UserData:
           Fn::Base64:
-            Fn::Join:
-            - ""
-            - - "#!/bin/bash \n"
-              - "snap install  joule-expansion --classic \n"
-              - "snap install microk8s --classic --channel="
-              - !Ref "KubernetesVersion"
-              - "/stable \n"
-              - "usermod -a -G microk8s ubuntu \n"
-              - "mkdir /home/ubuntu/.kube \n"
-              - "sudo chown -f -R ubuntu /home/ubuntu/.kube \n"
-              - "snap set joule-expansion provider=aws \n"
-              - "snap set joule-expansion applications=microk8s \n"
+            !Sub |
+              #!/bin/bash
+
+              snap install joule-expansion --classic
+              snap install microk8s --classic --channel=${KubernetesVersion}/stable
+              usermod -a -G microk8s ubuntu
+              mkdir /home/ubuntu/.kube
+              chown -f -R ubuntu /home/ubuntu/.kube
+              snap set joule-expansion provider=aws
+              snap set joule-expansion application=microk8s
         BlockDeviceMappings:
           - DeviceName: "/dev/sda1"
             Ebs:

--- a/examples/aws-microk8s/cloud-formation.yaml
+++ b/examples/aws-microk8s/cloud-formation.yaml
@@ -9,10 +9,10 @@ Parameters:
     Default: "MicroK8s"
   KeyPair:
     Description: Amazon EC2 Key Pair used to ssh to the cluster nodes
+    Type: "AWS::EC2::KeyPair::KeyName"
   LatestUbuntuFocalAMI:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/canonical/ubuntu/server/focal/stable/current/amd64/hvm/ebs-gp2/ami-id
-    Type: "AWS::EC2::KeyPair::KeyName"
   InstanceTypeParameter:
     Type: String
     Default: m4.large

--- a/examples/aws-microk8s/cloud-formation.yaml
+++ b/examples/aws-microk8s/cloud-formation.yaml
@@ -2,13 +2,33 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: ""
 Parameters:
   AppName:
+    Description: Name of the application the cluster will serve
     Type: String
     MinLength: '3'
     AllowedPattern: '[a-zA-Z0-9\(\)\.\-/_]+'
-    Default: "Joule"
+    Default: "MicroK8s"
+  KeyPair:
+    Description: Amazon EC2 Key Pair used to ssh to the cluster nodes
   LatestUbuntuFocalAMI:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/canonical/ubuntu/server/focal/stable/current/amd64/hvm/ebs-gp2/ami-id
+    Type: "AWS::EC2::KeyPair::KeyName"
+  InstanceTypeParameter:
+    Type: String
+    Default: m4.large
+    AllowedValues:
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+    Description: Select the instance type of the cluster nodes
+  KubernetesVersion:
+    Type: String
+    Default: 1.23
+    AllowedValues:
+      - 1.23
+      - 1.22
+      - 1.21
+    Description: The Kubernetes version
 Resources:
   SQSQueue:
     Type: "AWS::SQS::Queue"
@@ -97,7 +117,20 @@ Resources:
     Properties:
       LaunchTemplateName: !Sub "${AppName}"
       LaunchTemplateData:
-        UserData: "IyEvYmluL2Jhc2gKc25hcCBpbnN0YWxsICBqb3VsZS1leHBhbnNpb24gLS1jbGFzc2ljCnNuYXAgaW5zdGFsbCBtaWNyb2s4cyAtLWNsYXNzaWMgLS1jaGFubmVsIDEuMjEvc3RhYmxlCnVzZXJtb2QgLWEgLUcgbWljcm9rOHMgdWJ1bnR1Cm1rZGlyIC9ob21lL3VidW50dS8ua3ViZQpzdWRvIGNob3duIC1mIC1SIHVidW50dSAvaG9tZS91YnVudHUvLmt1YmUKc25hcCBzZXQgam91bGUtZXhwYW5zaW9uIHByb3ZpZGVyPWF3cwpzbmFwIHNldCBqb3VsZS1leHBhbnNpb24gYXBwbGljYXRpb25zPW1pY3Jvazhz"
+        UserData:
+          Fn::Base64:
+            Fn::Join:
+            - ""
+            - - "#!/bin/bash \n"
+              - "snap install  joule-expansion --classic \n"
+              - "snap install microk8s --classic --channel="
+              - !Ref "KubernetesVersion"
+              - "/stable \n"
+              - "usermod -a -G microk8s ubuntu] \n"
+              - "mkdir /home/ubuntu/.kube \n"
+              - "sudo chown -f -R ubuntu /home/ubuntu/.kube \n"
+              - "snap set joule-expansion provider=aws \n"
+              - "snap set joule-expansion applications=microk8s \n"
         BlockDeviceMappings:
           - DeviceName: "/dev/sda1"
             Ebs:
@@ -110,10 +143,10 @@ Resources:
             - InstanceProfile
             - Arn
         EbsOptimized: false
-        KeyName: "mia"
+        KeyName: !Sub "${KeyPair}"
         DisableApiTermination: false
         ImageId: !Ref LatestUbuntuFocalAMI
-        InstanceType: "m4.large"
+        InstanceType: !Sub "${InstanceTypeParameter}"
   AutoScalingAutoScalingGroup:
     Type: "AWS::AutoScaling::AutoScalingGroup"
     Properties:

--- a/examples/aws-microk8s/cloud-formation.yaml
+++ b/examples/aws-microk8s/cloud-formation.yaml
@@ -126,7 +126,7 @@ Resources:
               - "snap install microk8s --classic --channel="
               - !Ref "KubernetesVersion"
               - "/stable \n"
-              - "usermod -a -G microk8s ubuntu] \n"
+              - "usermod -a -G microk8s ubuntu \n"
               - "mkdir /home/ubuntu/.kube \n"
               - "sudo chown -f -R ubuntu /home/ubuntu/.kube \n"
               - "snap set joule-expansion provider=aws \n"

--- a/joule/providers/aws.py
+++ b/joule/providers/aws.py
@@ -114,7 +114,7 @@ class AwsProvider(BaseProvider):
         :return: Event
         """
         rx: List[Message] = self._queue.receive_messages(
-            VisibilityTimeout=5, WaitTimeSeconds=2, MaxNumberOfMessages=10
+            VisibilityTimeout=0, WaitTimeSeconds=1, MaxNumberOfMessages=10
         )
 
         for msg in rx:

--- a/joule/providers/aws.py
+++ b/joule/providers/aws.py
@@ -33,19 +33,22 @@ class AwsProvider(BaseProvider):
 
         self._region: str = ec2_metadata.region
 
-        queues: ListQueuesResultTypeDef = boto3.client(
-            "sqs", region_name=self._region
-        ).list_queues()
-        queue_url: str = queues["QueueUrls"][0]  # Get first queue found.
+        self._asg: AutoScalingClient = boto3.client(
+            "autoscaling", region_name=self._region
+        )
+        asg_name: str = self._asg.describe_auto_scaling_instances(
+            InstanceIds=[ec2_metadata.instance_id], MaxRecords=1
+        )["AutoScalingInstances"][0]["AutoScalingGroupName"]
 
+        # The queue has the same name as the AutoScalingGroupName
+        queue_url: str = boto3.client(
+            "sqs", region_name=self._region
+        ).get_queue_url(QueueName=asg_name)["QueueUrl"]
         self._queue: Queue = boto3.resource("sqs", region_name=self._region).Queue(
             queue_url
         )
 
         self._ec2: EC2Client = boto3.client("ec2", region_name=self._region)
-        self._asg: AutoScalingClient = boto3.client(
-            "autoscaling", region_name=self._region
-        )
 
     def mark_essential(self) -> None:
         """
@@ -111,7 +114,7 @@ class AwsProvider(BaseProvider):
         :return: Event
         """
         rx: List[Message] = self._queue.receive_messages(
-            VisibilityTimeout=0, WaitTimeSeconds=1, MaxNumberOfMessages=10
+            VisibilityTimeout=5, WaitTimeSeconds=2, MaxNumberOfMessages=10
         )
 
         for msg in rx:

--- a/joule/providers/aws.py
+++ b/joule/providers/aws.py
@@ -41,9 +41,9 @@ class AwsProvider(BaseProvider):
         )["AutoScalingInstances"][0]["AutoScalingGroupName"]
 
         # The queue has the same name as the AutoScalingGroupName
-        queue_url: str = boto3.client(
-            "sqs", region_name=self._region
-        ).get_queue_url(QueueName=asg_name)["QueueUrl"]
+        queue_url: str = boto3.client("sqs", region_name=self._region).get_queue_url(
+            QueueName=asg_name
+        )["QueueUrl"]
         self._queue: Queue = boto3.resource("sqs", region_name=self._region).Queue(
             queue_url
         )
@@ -96,11 +96,8 @@ class AwsProvider(BaseProvider):
         result: DescribeTagsResultTypeDef = self._ec2.describe_tags(
             Filters=[
                 {"Name": "resource-id", "Values": [self._instance_id]},
-                {
-                    "Name": "key",
-                    "Values": [self._tag_enrolled["Key"]],
-                },
-            ],
+                {"Name": "key", "Values": [self._tag_enrolled["Key"]]},
+            ]
         )
 
         if result.get("Tags", None):


### PR DESCRIPTION
A few improvements:
- Parameters in the CF:
    * Key pairs in a drop down menu populated with what the user already has
    * MicroK8s version to be installed
    * Instance types m4 large, xlarge and 2xlarge for now
- UserData in CF human readable and injecting the MicroK8s version
- We use the message queue with the correct name and not the first one available.
- We make sure we have 5 seconds to acknowledge we processed a message. This was causing multiple instances to process the same message resulting in errors like:
```
Feb 02 15:43:37 ip-172-31-13-91 joule-expansion.joule-expansion[24728]:   File "/snap/joule-expansion/52/lib/python3.8/site-packages/joule/providers/__init__.py", line 111, in loop
Feb 02 15:43:37 ip-172-31-13-91 joule-expansion.joule-expansion[24728]:     app.terminate(self, event)
Feb 02 15:43:37 ip-172-31-13-91 joule-expansion.joule-expansion[24728]:   File "/snap/joule-expansion/52/lib/python3.8/site-packages/joule/applications/microk8s.py", line 129, in terminate
Feb 02 15:43:37 ip-172-31-13-91 joule-expansion.joule-expansion[24728]:     hostname: str = desc["items"][0]["metadata"]["labels"]["kubernetes.io/hostname"]
Feb 02 15:43:37 ip-172-31-13-91 joule-expansion.joule-expansion[24728]: IndexError: list index out of range
Feb 02 15:43:37 ip-172-31-13-91 systemd[1]: snap.joule-expansion.joule-expansion.service: Main process exited, code=exited, status=1/FAILURE
```
and repetitions:
```
Feb 02 16:21:37 ip-172-31-13-134 joule-expansion.joule-expansion[3775]: 2022-02-02 16:21:37,306 INFO:LAUNCH event.
Feb 02 16:21:37 ip-172-31-13-134 sudo[7920]:     root : TTY=unknown ; PWD=/var/snap/joule-expansion/52 ; USER=root ; COMMAND=/snap/bin/microk8s add-node --token-ttl -1
Feb 02 16:21:37 ip-172-31-13-134 sudo[7920]: pam_unix(sudo:session): session opened for user root by (uid=0)
Feb 02 16:21:37 ip-172-31-13-134 sudo[7920]: pam_unix(sudo:session): session closed for user root
Feb 02 16:21:37 ip-172-31-13-134 joule-expansion.joule-expansion[3775]: 2022-02-02 16:21:37,599 INFO:LAUNCH event.
Feb 02 16:21:37 ip-172-31-13-134 sudo[7974]:     root : TTY=unknown ; PWD=/var/snap/joule-expansion/52 ; USER=root ; COMMAND=/snap/bin/microk8s add-node --token-ttl -1
Feb 02 16:21:37 ip-172-31-13-134 sudo[7974]: pam_unix(sudo:session): session opened for user root by (uid=0)
Feb 02 16:21:37 ip-172-31-13-134 sudo[7974]: pam_unix(sudo:session): session closed for user root
Feb 02 16:21:37 ip-172-31-13-134 joule-expansion.joule-expansion[3775]: 2022-02-02 16:21:37,899 INFO:LAUNCH event.
Feb 02 16:21:37 ip-172-31-13-134 sudo[8027]:     root : TTY=unknown ; PWD=/var/snap/joule-expansion/52 ; USER=root ; COMMAND=/snap/bin/microk8s add-node --token-ttl -1
Feb 02 16:21:37 ip-172-31-13-134 sudo[8027]: pam_unix(sudo:session): session opened for user root by (uid=0)
Feb 02 16:21:38 ip-172-31-13-134 sudo[8027]: pam_unix(sudo:session): session closed for user root
Feb 02 16:21:38 ip-172-31-13-134 joule-expansion.joule-expansion[3775]: 2022-02-02 16:21:38,209 INFO:LAUNCH event.
Feb 02 16:21:38 ip-172-31-13-134 sudo[8118]:     root : TTY=unknown ; PWD=/var/snap/joule-expansion/52 ; USER=root ; COMMAND=/snap/bin/microk8s add-node --token-ttl -1
Feb 02 16:21:38 ip-172-31-13-134 sudo[8118]: pam_unix(sudo:session): session opened for user root by (uid=0)
```