### PR TITLE
Package python in the snap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="joule",
     version="0.1.0",
-    url="https://github.com/joedborg/joule",
+    url="https://github.com/canonical/joule",
     license="Apache License 2.0",
     author="Joe Borg",
     author_email="joseph.borg@canonical.com",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,17 @@ parts:
       - wrapper.sh
   joule-expansion:
     plugin: python
-    python-packages:
-      - wheel
+    stage-packages:
+      - libpython3-stdlib
+      - libpython3.8-stdlib
+      - libpython3.8-minimal
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
+      - python3-venv
+      - python3-minimal
+      - python3-distutils
+      - python3-pkg-resources
+      - python3.8-minimal
     source: .
+


### PR DESCRIPTION
For core20 bases python comes from the base snap. This means that classic snaps would better package their python. 